### PR TITLE
Modified the protocols_csv_2_md.py to accomodate kramdown issue.

### DIFF
--- a/src/ibex_imaging_knowledge_base_utilities/protocols_csv_2_md.py
+++ b/src/ibex_imaging_knowledge_base_utilities/protocols_csv_2_md.py
@@ -41,7 +41,14 @@ def _description_2_md(description):
             num_spaces = num_spaces + 1
             if num_spaces == num_words:
                 break
-    return f"<details ><summary>{description[0:i]}...</summary><p>{description}</p></details>"
+    # Because the html code will go inside a markdown table and we are using kramdown,
+    # default markdown renderer for jekyll, we need to wrap it with nomarkdown to tell kramdown to leave it
+    # as is.
+    return (
+        "{::nomarkdown}"
+        + f"<details ><summary>{description[0:i]}...</summary><p>{description}</p></details>"
+        + "{:/}"
+    )
 
 
 def protocols_csv_to_md(template_file_path, csv_file_path, output_dir):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -264,7 +264,7 @@ class TestProtocolsCSV2MD(BaseTest):
             (
                 "protocols.md.in",
                 "protocols.csv",
-                "b48e11fb1917376b9998c14608bfef7d",
+                "ae265c655481dc8cabf540f82b804b71",
             )
         ],
     )


### PR DESCRIPTION
Kramdown rendered html incorrectly, didn't leave it as is. Now we explicitly specify to leave it as is by wrapping it: {::nomarkdown} html_here {:/}.