### PR TITLE
Changing the argparse custom argument types.

### DIFF
--- a/src/ibex_imaging_knowledge_base_utilities/argparse_types.py
+++ b/src/ibex_imaging_knowledge_base_utilities/argparse_types.py
@@ -22,23 +22,14 @@ import argparse
 # definitions of argparse types, enables argparse to validate the command line parameters
 
 
-def file_path_endswith_md_in(path):
-    p = pathlib.Path(path)
-    if p.is_file() and path.endswith(".md.in"):
+def file_path_endswith(path_str, ends_with_pattern=""):
+    p = pathlib.Path(path_str)
+    if p.is_file() and path_str.endswith(ends_with_pattern):
         return p
     else:
         raise argparse.ArgumentTypeError(
-            f'Invalid argument ({path}), not a file path, file does not exist, or path does not end with ".md.in".'
-        )
-
-
-def file_path(path):
-    p = pathlib.Path(path)
-    if p.is_file():
-        return p
-    else:
-        raise argparse.ArgumentTypeError(
-            f"Invalid argument ({path}), not a file path or file does not exist."
+            f"Invalid argument ({path_str}), not a file path, file does not exist, or path does not"
+            + f' end with "{ends_with_pattern}".'
         )
 
 

--- a/src/ibex_imaging_knowledge_base_utilities/bib2md.py
+++ b/src/ibex_imaging_knowledge_base_utilities/bib2md.py
@@ -21,7 +21,7 @@ import subprocess
 import tempfile
 import argparse
 import sys
-from .argparse_types import file_path
+from .argparse_types import file_path_endswith
 
 """
 This script creates the publications markdown page from the publications.bib bibliography
@@ -108,13 +108,15 @@ def main(argv=None):
         description="Create publications markdown file from a bib file."
     )
     parser.add_argument(
-        "bib_file", type=file_path, help="bibliography file in bibtex/biblatex format"
+        "bib_file",
+        type=lambda x: file_path_endswith(x, ".bib"),
+        help="bibliography file in bibtex/biblatex format",
     )
     parser.add_argument(
         "csl_file",
-        type=file_path,
+        type=lambda x: file_path_endswith(x, ".csl"),
         help="citation style language file for formatting the bibliography "
-        + "(donwload and view style files from zotero site https://www.zotero.org/styles)",
+        + "(download and view style files from zotero site https://www.zotero.org/styles)",
     )
     parser.add_argument("output_file", type=str, help="markdown output file name")
     args = parser.parse_args(argv)

--- a/src/ibex_imaging_knowledge_base_utilities/csv_2_supporting.py
+++ b/src/ibex_imaging_knowledge_base_utilities/csv_2_supporting.py
@@ -21,7 +21,7 @@ import numpy as np
 import pathlib
 import argparse
 import sys
-from .argparse_types import file_path, dir_path
+from .argparse_types import file_path_endswith, dir_path
 
 """
 This utility script facilitates batch creation of supporting material files from a comma-separated-value
@@ -265,8 +265,10 @@ def main(argv=None):
         description="Create supporting material files from a csv which has the same structure as the "
         + 'reagent_resources.csv and two additional columns "Publications" and "Notes".'
     )
-    parser.add_argument("csv_file", type=file_path)
-    parser.add_argument("supporting_template_file", type=file_path)
+    parser.add_argument("csv_file", type=lambda x: file_path_endswith(x, ".csv"))
+    parser.add_argument(
+        "supporting_template_file", type=lambda x: file_path_endswith(x, ".md.in")
+    )
     parser.add_argument("supporting_material_root_dir", type=dir_path)
     args = parser.parse_args(argv)
 

--- a/src/ibex_imaging_knowledge_base_utilities/datadict_glossary_2_contrib_md.py
+++ b/src/ibex_imaging_knowledge_base_utilities/datadict_glossary_2_contrib_md.py
@@ -19,7 +19,7 @@
 import sys
 import pandas as pd
 import argparse
-from .argparse_types import file_path, file_path_endswith_md_in, dir_path
+from .argparse_types import file_path_endswith, dir_path
 
 
 def dict_glossary_to_md(
@@ -54,16 +54,18 @@ def main(argv=None):
     )
     parser.add_argument(
         "md_template_file",
-        type=file_path_endswith_md_in,
+        type=lambda x: file_path_endswith(x, ".md.in"),
         help='Path to template markdown file which contains the strings "{reagent_metadata_table}" and "{glossary_table}".',  # noqa E501
     )
     parser.add_argument(
         "data_dictionary",
-        type=file_path,
+        type=lambda x: file_path_endswith(x, ".csv"),
         help="Path to the reagent data dictionary csv file.",
     )
     parser.add_argument(
-        "glossary", type=file_path, help="Path to the glossary csv file."
+        "glossary",
+        type=lambda x: file_path_endswith(x, ".csv"),
+        help="Path to the glossary csv file.",
     )
     parser.add_argument(
         "output_dir",

--- a/src/ibex_imaging_knowledge_base_utilities/fluorescent_probes_csv_2_md.py
+++ b/src/ibex_imaging_knowledge_base_utilities/fluorescent_probes_csv_2_md.py
@@ -19,7 +19,7 @@
 import pandas as pd
 import argparse
 import sys
-from .argparse_types import file_path, file_path_endswith_md_in, dir_path
+from .argparse_types import file_path_endswith, dir_path
 
 
 """
@@ -63,11 +63,13 @@ def main(argv=None):
     )
     parser.add_argument(
         "md_template_file",
-        type=file_path_endswith_md_in,
+        type=lambda x: file_path_endswith(x, ".md.in"),
         help='Path to template markdown file which contains the string "{probe_table}".',
     )
     parser.add_argument(
-        "csv_file", type=file_path, help="Path to the fluorescent_probes.csv file."
+        "csv_file",
+        type=lambda x: file_path_endswith(x, ".csv"),
+        help="Path to the fluorescent_probes.csv file.",
     )
     parser.add_argument(
         "output_dir",

--- a/src/ibex_imaging_knowledge_base_utilities/protocols_csv_2_md.py
+++ b/src/ibex_imaging_knowledge_base_utilities/protocols_csv_2_md.py
@@ -19,17 +19,17 @@
 import pandas as pd
 import argparse
 import sys
-from .argparse_types import file_path, file_path_endswith_md_in, dir_path
+from .argparse_types import file_path_endswith, dir_path
 
 
 """
 This script converts the IBEX knowledge-base protocols.csv file to markdown.
 
-This script is automatically run when modifications to the protocols.csv file are merged
+The script is automatically run when modifications to the protocols.csv file are merged
 into the main branch of the ibex_knowledge_base repository (see .github/workflows/data2md.yml).
 
 Assumption: The protocols.csv file is valid. It conforms to the expected format
-            (three columns titled: Title,URL,Details).
+            (includes columns titled: Title,URL,Details).
 """
 
 
@@ -86,11 +86,13 @@ def main(argv=None):
     )
     parser.add_argument(
         "md_template_file",
-        type=file_path_endswith_md_in,
+        type=lambda x: file_path_endswith(x, ".md.in"),
         help='Path to template markdown file which contains the string "{protocol_table}".',
     )
     parser.add_argument(
-        "csv_file", type=file_path, help="Path to the protocols.csv file."
+        "csv_file",
+        type=lambda x: file_path_endswith(x, ".csv"),
+        help="Path to the protocols.csv file.",
     )
     parser.add_argument(
         "output_dir",

--- a/src/ibex_imaging_knowledge_base_utilities/reagent_resources_csv_2_md_url.py
+++ b/src/ibex_imaging_knowledge_base_utilities/reagent_resources_csv_2_md_url.py
@@ -20,7 +20,7 @@ import pandas as pd
 import argparse
 import sys
 import pathlib
-from .argparse_types import file_path, file_path_endswith_md_in, dir_path
+from .argparse_types import file_path_endswith, dir_path
 import requests
 from itertools import chain
 
@@ -272,15 +272,17 @@ def main(argv=None):
     )
     parser.add_argument(
         "md_template_file",
-        type=file_path_endswith_md_in,
+        type=lambda x: file_path_endswith(x, ".md.in"),
         help='Path to template markdown file which contains the string "{reagent_resources_table}".',
     )
     parser.add_argument(
-        "csv_file", type=file_path, help="Path to the reagent_resources.csv file."
+        "csv_file",
+        type=lambda x: file_path_endswith(x, ".csv"),
+        help="Path to the reagent_resources.csv file.",
     )
     parser.add_argument(
         "vendor_to_website",
-        type=file_path,
+        type=lambda x: file_path_endswith(x, ".csv"),
         help="Path to csv file mapping between vendor name and website/URL, column headers are Vendor, URL.",
     )
     parser.add_argument(

--- a/src/ibex_imaging_knowledge_base_utilities/update_index_md_stats.py
+++ b/src/ibex_imaging_knowledge_base_utilities/update_index_md_stats.py
@@ -19,7 +19,7 @@
 import pandas as pd
 import argparse
 import sys
-from .argparse_types import file_path_endswith_md_in, file_path, dir_path
+from .argparse_types import file_path_endswith, dir_path
 
 """
 This script computes statistics from the reagent_resources.csv file and injects them into the input markdown file.
@@ -118,7 +118,7 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description="Update stats in the index.md file.")
     parser.add_argument(
         "md_template_file",
-        type=file_path_endswith_md_in,
+        type=lambda x: file_path_endswith(x, ".md.in"),
         help="Path to template markdown file which contains the following strings:\n\t"
         + "\n\t".join(
             [
@@ -131,7 +131,9 @@ def main(argv=None):
         ),
     )
     parser.add_argument(
-        "input_csv", type=file_path, help="Path to the reagent_resources.csv file."
+        "input_csv",
+        type=lambda x: file_path_endswith(x, ".csv"),
+        help="Path to the reagent_resources.csv file.",
     )
     parser.add_argument(
         "output_dir",

--- a/src/ibex_imaging_knowledge_base_utilities/validate_zenodo_json.py
+++ b/src/ibex_imaging_knowledge_base_utilities/validate_zenodo_json.py
@@ -19,7 +19,7 @@
 import sys
 import json
 import argparse
-from .argparse_types import file_path
+from .argparse_types import file_path_endswith
 from .url_exists import check_urls
 
 """
@@ -166,7 +166,11 @@ def main(argv=None):
     if argv is None:  # script was invoked from commandline
         argv = sys.argv[1:]
     parser = argparse.ArgumentParser(description="Validate .zenodo.json file content.")
-    parser.add_argument("zenodo_json", type=file_path, help=".zenodo.json file")
+    parser.add_argument(
+        "zenodo_json",
+        type=lambda x: file_path_endswith(x, ".json"),
+        help=".zenodo.json file",
+    )
     args = parser.parse_args(argv)
 
     return validate_zenodo_json(args.zenodo_json)

--- a/src/ibex_imaging_knowledge_base_utilities/videos_csv_2_md.py
+++ b/src/ibex_imaging_knowledge_base_utilities/videos_csv_2_md.py
@@ -19,17 +19,17 @@
 import pandas as pd
 import argparse
 import sys
-from .argparse_types import file_path, file_path_endswith_md_in, dir_path
+from .argparse_types import file_path_endswith, dir_path
 from datetime import date
 
 """
 This script converts the IBEX knowledge-base videos.csv file to markdown.
 
-This script is automatically run when modifications to the videos.csv file are merged
+The script is automatically run when modifications to the videos.csv file are merged
 into the main branch of the ibex_knowledge_base repository (see .github/workflows/data2md.yml).
 
 Assumption: The videos.csv file is valid. It conforms to the expected format
-            (three columns titled: Title,URL,Details,Category,Year,Month,Day).
+            (includes columns titled: Title,URL,Details,Category,Year,Month,Day).
             Category entries are either "general" or "tutorial".
 """
 
@@ -100,10 +100,14 @@ def main(argv=None):
     )
     parser.add_argument(
         "md_template_file",
-        type=file_path_endswith_md_in,
+        type=lambda x: file_path_endswith(x, ".md.in"),
         help='Path to template markdown file which contains the strings "{general_table}" and "{tutorial_table}".',
     )
-    parser.add_argument("csv_file", type=file_path, help="Path to the video.csv file.")
+    parser.add_argument(
+        "csv_file",
+        type=lambda x: file_path_endswith(x, ".csv"),
+        help="Path to the video.csv file.",
+    )
     parser.add_argument(
         "output_dir",
         type=dir_path,

--- a/src/ibex_imaging_knowledge_base_utilities/zenodo_json_2_thewho_md.py
+++ b/src/ibex_imaging_knowledge_base_utilities/zenodo_json_2_thewho_md.py
@@ -19,7 +19,7 @@
 import sys
 import json
 import argparse
-from .argparse_types import file_path, file_path_endswith_md_in, dir_path
+from .argparse_types import file_path_endswith, dir_path
 
 
 def zenodo_creators_to_md(template_file_path, zenodo_json_file_path, output_dir):
@@ -46,11 +46,13 @@ def main(argv=None):
     )
     parser.add_argument(
         "md_template_file",
-        type=file_path_endswith_md_in,
+        type=lambda x: file_path_endswith(x, ".md.in"),
         help='Path to template markdown file which contains the string "{contributor_list}".',
     )
     parser.add_argument(
-        "zenodo_json", type=file_path, help="Path to the .zenodo.json file."
+        "zenodo_json",
+        type=lambda x: file_path_endswith(x, ".json"),
+        help="Path to the .zenodo.json file.",
     )
     parser.add_argument(
         "output_dir",


### PR DESCRIPTION
Previously we had a file_path and file_path_endswith_md custom types. These are now combined into a file_path_endswith custom type which is parameterized with the endswith argument. The same custom type checks if the given parameter is a file, no specific extension. Or if a specific extension is also given, check if the parameter is a file with the user specified extension.