### PR TITLE
Add configuration for dependabot to automatically create PRs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
The dependabot GitHub alerts system checks dependencies and can create alerts and automatic PRs to update dependencies that have vulnerabilities. Configure it to do so for the GitHub actions.