### PR TITLE
Improve URL checking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ needed. This is equivalent to summarizing all activity on a feature branch versu
 
 ## Unreleased
 
+## v0.9.6
+
+### Changed
+
+validation_utilities - Improvements to the URL checking code. Increase the chances of not getting a 403 (forbidden, server refused to authorize request) by mimicking a browser. This doesn't solve the issue when sites really don't want to be scanned by scripts/bots, just improves the chances.
+
 ## v0.9.4
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ibex_imaging_knowledge_base_utilities"
-version = "0.9.4"
+version = "0.9.6"
 authors = [{ name="Ziv Yaniv", email="zivyaniv@nih.gov" },
 ]
 description = "Utility scripts used for managing the IBEX Imaging Community Knowledge-Base"


### PR DESCRIPTION
Improving URL checking by using sessions for same domain and attempting to mimic a browser so increase chances of not getting 403 error. This is not a comprehensive solution and still doesn't work for many sites that have DOS protection in place and do not want scripts/bots to access them.